### PR TITLE
Extend script runners

### DIFF
--- a/mix
+++ b/mix
@@ -1,2 +1,2 @@
-#!/bin/bash
-docker-compose run --rm app mix "$@"
+#!/usr/bin/env bash
+./run mix "$@"

--- a/mix
+++ b/mix
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-./run mix "$@"
+./run mix $@

--- a/npm
+++ b/npm
@@ -1,0 +1,1 @@
+./run sh -c "cd assets; npm $@"

--- a/run
+++ b/run
@@ -1,2 +1,2 @@
-#!/bin/bash
-docker-compose run --rm app "$@"
+#!/usr/bin/env bash
+docker-compose run --rm app "$@; chown -R $(id -u):$(id -g) ."

--- a/run
+++ b/run
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
-docker-compose run --rm app "$@; chown -R $(id -u):$(id -g) ."
+docker-compose run --rm app $@
+docker-compose run --rm app chown -R $(id -u):$(id -g) .


### PR DESCRIPTION
I extended the script runners to:

- automatically update the file permissions in `src/` to the current user from outside docker, to avoid permissions problems due to docker running as root.
- remove redundancy between `mix` and `run` by having `mix` pass through to `run`
- add an `npm` command that calls `npm` in the right directory.