### PR TITLE
Fix markdown link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ git clone -b 1.5.9 https://github.com/nicbet/docker-phoenix ~/Projects/hello-pho
 
 ### New with Elixir 1.9: Releases
 
-Follow this [Github Gist]
-(https://gist.github.com/nicbet/102f16359828405ce34ca083976986e1) to prepare a minimal Docker release image based on Alpine Linux (about 38MB for a Phoenix Webapp).
+Follow this [Github Gist](https://gist.github.com/nicbet/102f16359828405ce34ca083976986e1)
+to prepare a minimal Docker release image based on Alpine Linux (about 38MB for a Phoenix Webapp).
 
 ### New Application from Scratch
 


### PR DESCRIPTION
Small fix in README to change the spacing for a markdown link.

## Before

![Screen Shot 2021-05-23 at 12 53 45 PM](https://user-images.githubusercontent.com/691365/119269494-f0553700-bbc5-11eb-8040-4a81f9f7e18f.png)


## After

![Screen Shot 2021-05-23 at 12 53 29 PM](https://user-images.githubusercontent.com/691365/119269501-f64b1800-bbc5-11eb-9274-3cfdb1387528.png)
