### PR TITLE
Fixed tag name

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can specify a particular Phoenix version by targeting the corresponding rele
 For instance, for a dockerized development environment for Phoenix 1.6.0 you could run:
 
 ```
-git clone -b 1.6.0 https://github.com/nicbet/docker-phoenix ~/Projects/hello-phoenix
+git clone -b v1.6.0 https://github.com/nicbet/docker-phoenix ~/Projects/hello-phoenix
 ```
 
 ### New with Elixir 1.9: Releases


### PR DESCRIPTION
The tag name has a `v` with the semver, the previous command wasn't working for me on Windows 11 :) thanks for the project, I think it's going to be super helpful!