### PR TITLE
Add Version Number for Node JS,  as well as ENV Param for Phoenix

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM restlessronin/phoenix:1.6.2
+FROM nicbet/phoenix:1.6.2
 
 RUN apt-get install -y ruby \
   && gem install --no-ri --no-rdoc htmlbeautifier \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM nicbet/phoenix:1.6.2
+FROM restlessronin/phoenix:1.6.2
 
 RUN apt-get install -y ruby \
   && gem install --no-ri --no-rdoc htmlbeautifier \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM elixir:1.12.3
 LABEL maintainer="Nicolas Bettenburg <nicbet@gmail.com>"
 
-ENV PHOENIX_VERSION=1.6.2
-ENV NODEJS_VERSION=17.x
+ARG PHOENIX_VERSION=1.6.2
+ARG NODEJS_VERSION=12.x
 
 RUN mix local.hex --force \
   && mix archive.install --force hex phx_new ${PHOENIX_VERSION} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM elixir:1.12.3
 LABEL maintainer="Nicolas Bettenburg <nicbet@gmail.com>"
 
+ENV PHOENIX_VERSION=1.6.2
+ENV NODEJS_VERSION=17.x
+
 RUN mix local.hex --force \
-  && mix archive.install --force hex phx_new 1.6.2 \
+  && mix archive.install --force hex phx_new ${PHOENIX_VERSION} \
   && apt-get update \
-  && curl -sL https://deb.nodesource.com/setup_12.x | bash \
+  && curl -sL https://deb.nodesource.com/setup_${NODEJS_VERSION} | bash \
   && apt-get install -y apt-utils \
   && apt-get install -y nodejs \
   && apt-get install -y build-essential \

--- a/buildarch.sh
+++ b/buildarch.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-DOCKERUSER=restlessronin
-docker buildx build --push --platform linux/$1 -t ${DOCKERUSER}/phoenix:$1-$2 .
+
+docker buildx build --push --platform linux/$1 -t nicbet/phoenix:$1-$2 .

--- a/buildarch.sh
+++ b/buildarch.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DOCKERUSER=restlessronin
+docker buildx build --push --platform linux/$1 -t ${DOCKERUSER}/phoenix:$1-$2 .

--- a/buildmulti.sh
+++ b/buildmulti.sh
@@ -2,3 +2,4 @@
 
 DOCKERUSER=restlessronin
 docker manifest create ${DOCKERUSER}/phoenix:$1 --amend ${DOCKERUSER}/phoenix:amd64-$1 --amend ${DOCKERUSER}/phoenix:arm64-$1
+docker manifest push ${DOCKERUSER}/phoenix:$1 

--- a/buildmulti.sh
+++ b/buildmulti.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+DOCKERUSER=restlessronin
+docker manifest create ${USER}/phoenix:ma-$1 --amend ${DOCKERUSER}/phoenix:amd64-$1 --amend ${DOCKERUSER}/phoenix:arm64-$1

--- a/buildmulti.sh
+++ b/buildmulti.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-DOCKERUSER=restlessronin
-docker manifest create ${DOCKERUSER}/phoenix:$1 --amend ${DOCKERUSER}/phoenix:amd64-$1 --amend ${DOCKERUSER}/phoenix:arm64-$1
-docker manifest push ${DOCKERUSER}/phoenix:$1 
+docker manifest create nicbet/phoenix:$1 --amend nicbet/phoenix:amd64-$1 --amend nicbet/phoenix:arm64-$1
+docker manifest push nicbet/phoenix:$1 

--- a/buildmulti.sh
+++ b/buildmulti.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 DOCKERUSER=restlessronin
-docker manifest create ${USER}/phoenix:ma-$1 --amend ${DOCKERUSER}/phoenix:amd64-$1 --amend ${DOCKERUSER}/phoenix:arm64-$1
+docker manifest create ${DOCKERUSER}/phoenix:$1 --amend ${DOCKERUSER}/phoenix:amd64-$1 --amend ${DOCKERUSER}/phoenix:arm64-$1


### PR DESCRIPTION
I needed to be able to build a more recent NodeJS version into the container, so I parameterized both the phoenix version as well as the NodeJS version.

My primary machine is a Mac M1 which has problems with amd64 images. I added a couple of build scripts to simplify multi-arch builds (via manifest pushing, since I couldn't get buildx working as advertised). My process was:

run on amd64 machine:

`./buildarch.sh amd64 1.6.2`

then run on an m1

```
./buildarch.sh arm64 1.6.2
./buildmulti.sh 1.6.2
```
