### PR TITLE
specify htmlbeautifier version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 FROM nicbet/phoenix:1.6.2
 
 RUN apt-get install -y ruby \
-  && gem install --no-ri --no-rdoc htmlbeautifier \
+  && gem install --no-ri --no-rdoc htmlbeautifier -v 1.3.1 \
   && npm i -g yarn \
   && apt-get autoremove -y \
   && apt-get clean -y \


### PR DESCRIPTION
the latest version of htmlbeautifier is expecting a newer version of Ruby than is in the debian repo used Dockerfile.

i'm not familiar enough with Ruby to know what is the canonical repo to use, so I specified the version of htmlbeautifier.

Without this change, the Dockerfile isn't compiling on my M1.

Thanks @nicbet for enabling M1 images.