### PR TITLE
Enable gitpod integration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 FROM nicbet/phoenix:1.6.2
 
 RUN apt-get install -y ruby \
-  && gem install --no-ri --no-rdoc htmlbeautifier \
+  && gem install --no-ri --no-rdoc htmlbeautifier -v 1.3.1 \
   && npm i -g yarn \
   && apt-get autoremove -y \
   && apt-get clean -y \

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,8 +4,8 @@ tasks:
       docker-compose -f docker-compose.yml pull
     command: |
       docker-compose -f docker-compose.yml up --no-start
-      && docker-compose -f docker-compose.yml start db
-      && docker-compose -f docker-compose.yml run --service-ports app bash
+      docker-compose -f docker-compose.yml start db
+      docker-compose -f docker-compose.yml run --service-ports app bash
 
 ports:
   - port: 4000

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,28 @@
+tasks:
+  - name: Gitpod Phoenix
+    init: |
+      docker-compose -f docker-compose.yml pull
+    command: |
+      docker-compose -f docker-compose.yml up --no-start
+      && docker-compose -f docker-compose.yml start db
+      && docker-compose -f docker-compose.yml run --service-ports app bash
+
+ports:
+  - port: 4000
+    onOpen: open-browser
+  - port: 5432
+    onOpen: ignore
+
+github:
+  prebuilds:
+    master: true
+    branches: true
+    pullRequests: true
+    pullRequestsFromForks: true
+    addCheck: true
+    addComment: true
+    addBadge: false
+
+vscode:
+  extensions:
+    - elixir-lsp.elixir-ls

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ After cloning this repository, open the folder in Visual Studio Code's Remote Ex
 
 See [https://code.visualstudio.com/docs/remote/containers](https://code.visualstudio.com/docs/remote/containers) for more details.
 
+### New: Support for Gitpod Workspaces
+
+After cloning this repository, open the URL of any branch in gitpod to get a full Cloud Development Environment (with PostgreSQL Database) spun up automatically. This has been tested on Github, but the same basic idea should work on Gitlab, Bitbucket, etc.
+
+See https://www.gitpod.io/docs/getting-started if you're unfamiliar with Gitpod
+
+To see a demo, open this repo on Gitpod by clicking the button below
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/restlessronin/docker-phoenix/tree/enable-gitpod)
+
 ## Getting Started
 
 It's so simple: just clone this repository.


### PR DESCRIPTION
Hi @nicbet , 

I recently did a gitpod integration for a phoenix project I'm working on, and wanted to make it public. Rather than create a separate project which is very similar to this one, I thought it would be better to contribute it here. The project would  then conceptually have integrations with various "dev container" implementations (like the VS Code integration). 

I've simplified the integration so that it will work with the existing project structure and docker-compose files.

I hope it makes sense for you to add it. 
