### PR TITLE
Update readme to correctly specify version tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can specify a particular Phoenix version by targeting the corresponding rele
 For instance, for a dockerized development environment for Phoenix 1.6.6 you could run:
 
 ```
-git clone -b v1.6.6 https://github.com/nicbet/docker-phoenix ~/Projects/hello-phoenix
+git clone -b 1.6.6 https://github.com/nicbet/docker-phoenix ~/Projects/hello-phoenix
 ```
 
 ### New with Elixir 1.9: Releases


### PR DESCRIPTION
The tags don't have `v` in front of them.