### PR TITLE
update dockerfile to use --no-document instead of deprecated --no-ri --no-rdoc

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 FROM nicbet/phoenix:1.6.11
 
 RUN apt-get install -y ruby \
-  && gem install --no-ri --no-rdoc htmlbeautifier -v 1.3.1 \
+  && gem install --no-document htmlbeautifier -v 1.3.1 \
   && npm i -g yarn \
   && apt-get autoremove -y \
   && apt-get clean -y \


### PR DESCRIPTION
Update the Dockerfile in .devcontainer folder to install ruby with the latest --no-document flag instead of the deprecated --no-ri --no-rdoc flag.

--no-ri --no-rdoc causes opening of the container in vs-code to fail